### PR TITLE
Update email verification for non-admin users only

### DIFF
--- a/app/services/user_service.py
+++ b/app/services/user_service.py
@@ -71,10 +71,11 @@ class UserService:
 
             else:
                 new_user.verification_token = generate_verification_token()
-                await email_service.send_verification_email(new_user)
 
             session.add(new_user)
             await session.commit()
+            if new_user.role != UserRole.ADMIN:
+                await email_service.send_verification_email(new_user)
             return new_user
         except ValidationError as e:
             logger.error(f"Validation error during user creation: {e}")

--- a/tests/test_services/test_user_service.py
+++ b/tests/test_services/test_user_service.py
@@ -161,3 +161,20 @@ async def test_unlock_user_account(db_session, locked_user):
     assert unlocked, "The account should be unlocked"
     refreshed_user = await UserService.get_by_id(db_session, locked_user.id)
     assert not refreshed_user.is_locked, "The user should no longer be locked"
+
+# Test updating non-existent user
+async def test_update_non_existent_user(db_session):
+    non_existent_user_id = "non-existent-id"
+    updated_user = await UserService.update(db_session, non_existent_user_id, {"email": "new_email@example.com"})
+    assert updated_user is None
+
+# Test listing users beyond available range
+async def test_list_users_beyond_range(db_session):
+    users = await UserService.list_users(db_session, skip=1000, limit=10)
+    assert len(users) == 0
+
+# Test for account unlock using incorrect ID
+async def test_unlock_user_account_incorrect_id(db_session):
+    incorrect_user_id = "incorrect-id"
+    unlocked = await UserService.unlock_user_account(db_session, incorrect_user_id)
+    assert unlocked is False


### PR DESCRIPTION
Currently, email verification works on all users, needs to be applied only so that non-admin users get the verification and not admins.